### PR TITLE
add bigobj flag to solve fatal error in Visual Studio

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,10 @@ target_link_libraries(${OATPP_THIS_MODULE_NAME}
         PUBLIC ${PostgreSQL_LIBRARIES}
 )
 
+if(MSVC)
+        target_compile_options(${OATPP_THIS_MODULE_NAME} PRIVATE "/bigobj")
+endif()
+
 #######################################################################################################
 ## install targets
 


### PR DESCRIPTION
When I try to compile oatpp-postgresql in Visual Studio 15, I met following error message.
```
src\oatpp-postgresql\mapping\Deserializer.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
```

I make simple patch to workaround it.
I'm glad if this could be merged.