### PR TITLE
Issue #24 - insert DTO type ENUM as string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20)
 
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20)
 
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script
 ## use these variables to configure module installation
 
 set(OATPP_THIS_MODULE_NAME oatpp-postgresql) ## name of the module (also name of folders in installation dirs)
-set(OATPP_THIS_MODULE_VERSION "1.3.0") ## version of the module (also sufix of folders in installation dirs)
+set(OATPP_THIS_MODULE_VERSION "1.4.0") ## version of the module (also sufix of folders in installation dirs)
 set(OATPP_THIS_MODULE_LIBRARIES oatpp-postgresql) ## list of libraries to find when find_package is called
 set(OATPP_THIS_MODULE_TARGETS oatpp-postgresql) ## list of targets to install
 set(OATPP_THIS_MODULE_DIRECTORIES oatpp-postgresql) ## list of directories to install
@@ -91,6 +91,8 @@ endif()
 
 message("\n############################################################################")
 message("## ${OATPP_THIS_MODULE_NAME} module. Resolving dependencies...\n")
+
+set(PostgreSQL_ADDITIONAL_VERSIONS "17")
 
 find_package(PostgreSQL REQUIRED)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,8 @@ jobs:
       clean: all
     steps:
       - script: |
-          docker-compose build
+          docker compose build
         displayName: 'Compose build'
       - script: |
-          docker-compose run test
+          docker compose run test
         displayName: 'Compose run'

--- a/src/oatpp-postgresql/Connection.hpp
+++ b/src/oatpp-postgresql/Connection.hpp
@@ -26,8 +26,8 @@
 #define oatpp_postgresql_Connection_hpp
 
 #include "oatpp/orm/Connection.hpp"
-#include "oatpp/core/provider/Pool.hpp"
-#include "oatpp/core/Types.hpp"
+#include "oatpp/provider/Pool.hpp"
+#include "oatpp/Types.hpp"
 
 #include <libpq-fe.h>
 

--- a/src/oatpp-postgresql/ConnectionProvider.hpp
+++ b/src/oatpp-postgresql/ConnectionProvider.hpp
@@ -27,8 +27,8 @@
 
 #include "Connection.hpp"
 
-#include "oatpp/core/provider/Pool.hpp"
-#include "oatpp/core/Types.hpp"
+#include "oatpp/provider/Pool.hpp"
+#include "oatpp/Types.hpp"
 
 namespace oatpp { namespace postgresql {
 

--- a/src/oatpp-postgresql/Executor.cpp
+++ b/src/oatpp-postgresql/Executor.cpp
@@ -31,7 +31,9 @@
 
 #include "oatpp/orm/Transaction.hpp"
 
-#include "oatpp/core/macro/codegen.hpp"
+#include "oatpp/macro/codegen.hpp"
+
+#include "oatpp/base/Log.hpp"
 
 #include <vector>
 
@@ -152,7 +154,7 @@ std::shared_ptr<data::mapping::TypeResolver> Executor::createTypeResolver() {
 
 Executor::QueryParameter Executor::parseQueryParameter(const oatpp::String& paramName) {
 
-  parser::Caret caret(paramName);
+  utils::parser::Caret caret(paramName);
   auto nameLabel = caret.putLabel();
   if(caret.findChar('.') && caret.getPosition() < caret.getDataSize() - 1) {
 
@@ -499,7 +501,7 @@ void Executor::migrateSchema(const oatpp::String& script,
   }
 
   if(script->size() == 0) {
-    OATPP_LOGW("[oatpp::postgresql::Executor::migrateSchema()]", "Warning. Executing empty script for version %d", newVersion);
+    OATPP_LOGw("[oatpp::postgresql::Executor::migrateSchema()]", "Warning. Executing empty script for version {}", newVersion);
   }
 
   {
@@ -510,8 +512,8 @@ void Executor::migrateSchema(const oatpp::String& script,
 
     result = exec(script, connection);
     if(!result->isSuccess()) {
-      OATPP_LOGE("[oatpp::postgresql::Executor::migrateSchema()]",
-                 "Error. Migration failed for version %d. %s", newVersion, result->getErrorMessage()->c_str());
+      OATPP_LOGe("[oatpp::postgresql::Executor::migrateSchema()]",
+                 "Error. Migration failed for version {}. {}", newVersion, result->getErrorMessage()->c_str());
       throw std::runtime_error("[oatpp::postgresql::Executor::migrateSchema()]: "
                                "Error. Migration failed. " + *result->getErrorMessage());
 
@@ -519,7 +521,7 @@ void Executor::migrateSchema(const oatpp::String& script,
 
     result = updateSchemaVersion(newVersion, suffix, connection);
 
-    if(!result->isSuccess() || result->hasMoreToFetch() > 0) {
+    if(!result->isSuccess() || result->hasMoreToFetch()) {
       throw std::runtime_error("[oatpp::postgresql::Executor::migrateSchema()]: Error. Migration failed. Can't set new version.");
     }
 

--- a/src/oatpp-postgresql/Executor.hpp
+++ b/src/oatpp-postgresql/Executor.hpp
@@ -33,7 +33,7 @@
 #include "Types.hpp"
 
 #include "oatpp/orm/Executor.hpp"
-#include "oatpp/core/parser/Caret.hpp"
+#include "oatpp/utils/parser/Caret.hpp"
 
 #include <vector>
 

--- a/src/oatpp-postgresql/Types.hpp
+++ b/src/oatpp-postgresql/Types.hpp
@@ -32,7 +32,7 @@ namespace oatpp { namespace postgresql {
 /**
  * Uuid as oatpp primitive type.
  */
-typedef oatpp::data::mapping::type::Primitive<mapping::type::UuidObject, mapping::type::__class::Uuid> Uuid;
+typedef oatpp::data::type::Primitive<mapping::type::UuidObject, mapping::type::__class::Uuid> Uuid;
 
 }}
 

--- a/src/oatpp-postgresql/mapping/Deserializer.cpp
+++ b/src/oatpp-postgresql/mapping/Deserializer.cpp
@@ -41,36 +41,36 @@ Deserializer::InData::InData(PGresult* dbres, int row, int col, const std::share
 
 Deserializer::Deserializer() {
 
-  m_methods.resize(data::mapping::type::ClassId::getClassCount(), nullptr);
+  m_methods.resize(data::type::ClassId::getClassCount(), nullptr);
 
-  setDeserializerMethod(data::mapping::type::__class::String::CLASS_ID, &Deserializer::deserializeString);
-  setDeserializerMethod(data::mapping::type::__class::Any::CLASS_ID, &Deserializer::deserializeAny);
+  setDeserializerMethod(data::type::__class::String::CLASS_ID, &Deserializer::deserializeString);
+  setDeserializerMethod(data::type::__class::Any::CLASS_ID, &Deserializer::deserializeAny);
 
-  setDeserializerMethod(data::mapping::type::__class::Int8::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int8>);
-  setDeserializerMethod(data::mapping::type::__class::UInt8::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt8>);
+  setDeserializerMethod(data::type::__class::Int8::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int8>);
+  setDeserializerMethod(data::type::__class::UInt8::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt8>);
 
-  setDeserializerMethod(data::mapping::type::__class::Int16::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int16>);
-  setDeserializerMethod(data::mapping::type::__class::UInt16::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt16>);
+  setDeserializerMethod(data::type::__class::Int16::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int16>);
+  setDeserializerMethod(data::type::__class::UInt16::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt16>);
 
-  setDeserializerMethod(data::mapping::type::__class::Int32::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int32>);
-  setDeserializerMethod(data::mapping::type::__class::UInt32::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt32>);
+  setDeserializerMethod(data::type::__class::Int32::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int32>);
+  setDeserializerMethod(data::type::__class::UInt32::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt32>);
 
-  setDeserializerMethod(data::mapping::type::__class::Int64::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int64>);
-  setDeserializerMethod(data::mapping::type::__class::UInt64::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt64>);
+  setDeserializerMethod(data::type::__class::Int64::CLASS_ID, &Deserializer::deserializeInt<oatpp::Int64>);
+  setDeserializerMethod(data::type::__class::UInt64::CLASS_ID, &Deserializer::deserializeInt<oatpp::UInt64>);
 
-  setDeserializerMethod(data::mapping::type::__class::Float32::CLASS_ID, &Deserializer::deserializeFloat32);
-  setDeserializerMethod(data::mapping::type::__class::Float64::CLASS_ID, &Deserializer::deserializeFloat64);
-  setDeserializerMethod(data::mapping::type::__class::Boolean::CLASS_ID, &Deserializer::deserializeBoolean);
+  setDeserializerMethod(data::type::__class::Float32::CLASS_ID, &Deserializer::deserializeFloat32);
+  setDeserializerMethod(data::type::__class::Float64::CLASS_ID, &Deserializer::deserializeFloat64);
+  setDeserializerMethod(data::type::__class::Boolean::CLASS_ID, &Deserializer::deserializeBoolean);
 
-  setDeserializerMethod(data::mapping::type::__class::AbstractObject::CLASS_ID, nullptr);
-  setDeserializerMethod(data::mapping::type::__class::AbstractEnum::CLASS_ID, &Deserializer::deserializeEnum);
+  setDeserializerMethod(data::type::__class::AbstractObject::CLASS_ID, nullptr);
+  setDeserializerMethod(data::type::__class::AbstractEnum::CLASS_ID, &Deserializer::deserializeEnum);
 
-  setDeserializerMethod(data::mapping::type::__class::AbstractVector::CLASS_ID, &Deserializer::deserializeArray);
-  setDeserializerMethod(data::mapping::type::__class::AbstractList::CLASS_ID, &Deserializer::deserializeArray);
-  setDeserializerMethod(data::mapping::type::__class::AbstractUnorderedSet::CLASS_ID, &Deserializer::deserializeArray);
+  setDeserializerMethod(data::type::__class::AbstractVector::CLASS_ID, &Deserializer::deserializeArray);
+  setDeserializerMethod(data::type::__class::AbstractList::CLASS_ID, &Deserializer::deserializeArray);
+  setDeserializerMethod(data::type::__class::AbstractUnorderedSet::CLASS_ID, &Deserializer::deserializeArray);
 
-  setDeserializerMethod(data::mapping::type::__class::AbstractPairList::CLASS_ID, nullptr);
-  setDeserializerMethod(data::mapping::type::__class::AbstractUnorderedMap::CLASS_ID, nullptr);
+  setDeserializerMethod(data::type::__class::AbstractPairList::CLASS_ID, nullptr);
+  setDeserializerMethod(data::type::__class::AbstractUnorderedMap::CLASS_ID, nullptr);
 
   ////
 
@@ -78,7 +78,7 @@ Deserializer::Deserializer() {
 
 }
 
-void Deserializer::setDeserializerMethod(const data::mapping::type::ClassId& classId, DeserializerMethod method) {
+void Deserializer::setDeserializerMethod(const data::type::ClassId& classId, DeserializerMethod method) {
   const v_uint32 id = classId.id;
   if(id >= m_methods.size()) {
     m_methods.resize(id + 1, nullptr);
@@ -235,21 +235,21 @@ oatpp::Void Deserializer::deserializeBoolean(const Deserializer* _this, const In
 
 oatpp::Void Deserializer::deserializeEnum(const Deserializer* _this, const InData& data, const Type* type) {
 
-  auto polymorphicDispatcher = static_cast<const data::mapping::type::__class::AbstractEnum::PolymorphicDispatcher*>(
+  auto polymorphicDispatcher = static_cast<const data::type::__class::AbstractEnum::PolymorphicDispatcher*>(
     type->polymorphicDispatcher
   );
 
-  data::mapping::type::EnumInterpreterError e = data::mapping::type::EnumInterpreterError::OK;
+  data::type::EnumInterpreterError e = data::type::EnumInterpreterError::OK;
   const auto& value = _this->deserialize(data, polymorphicDispatcher->getInterpretationType());
 
-  const auto& result = polymorphicDispatcher->fromInterpretation(value, e);
+  const auto& result = polymorphicDispatcher->fromInterpretation(value, false, e); //useUnqualifiedNames is new to oatpp 1.4.0
 
-  if(e == data::mapping::type::EnumInterpreterError::OK) {
+  if(e == data::type::EnumInterpreterError::OK) {
     return result;
   }
 
   switch(e) {
-    case data::mapping::type::EnumInterpreterError::CONSTRAINT_NOT_NULL:
+    case data::type::EnumInterpreterError::CONSTRAINT_NOT_NULL:
       throw std::runtime_error("[oatpp::postgresql::mapping::Deserializer::deserializeEnum()]: Error. Enum constraint violated - 'NotNull'.");
 
     default:
@@ -315,7 +315,7 @@ oatpp::Void Deserializer::deserializeAny(const Deserializer* _this, const InData
   }
 
   auto value = _this->deserialize(data, valueType);
-  auto anyHandle = std::make_shared<data::mapping::type::AnyHandle>(value.getPtr(), value.getValueType());
+  auto anyHandle = std::make_shared<data::type::AnyHandle>(value.getPtr(), value.getValueType());
 
   return oatpp::Void(anyHandle, Any::Class::getType());
 }
@@ -343,7 +343,7 @@ oatpp::Void Deserializer::deserializeSubArray(const Type* type,
                              "Error. Unknown collection type.");
   }
 
-  auto dispatcher = static_cast<const data::mapping::type::__class::Collection::PolymorphicDispatcher*>(type->polymorphicDispatcher);
+  auto dispatcher = static_cast<const data::type::__class::Collection::PolymorphicDispatcher*>(type->polymorphicDispatcher);
   auto itemType = dispatcher->getItemType();
   auto collection = dispatcher->createObject();
 
@@ -402,7 +402,7 @@ oatpp::Void Deserializer::deserializeArray(const Deserializer* _this, const InDa
 
   auto ndim = (v_int32) ntohl(*((p_int32)data.data));
   if(ndim == 0) {
-    auto dispatcher = static_cast<const data::mapping::type::__class::Collection::PolymorphicDispatcher*>(type->polymorphicDispatcher);
+    auto dispatcher = static_cast<const data::type::__class::Collection::PolymorphicDispatcher*>(type->polymorphicDispatcher);
     return dispatcher->createObject(); // empty array
   }
 

--- a/src/oatpp-postgresql/mapping/Deserializer.cpp
+++ b/src/oatpp-postgresql/mapping/Deserializer.cpp
@@ -242,7 +242,7 @@ oatpp::Void Deserializer::deserializeEnum(const Deserializer* _this, const InDat
   data::type::EnumInterpreterError e = data::type::EnumInterpreterError::OK;
   const auto& value = _this->deserialize(data, polymorphicDispatcher->getInterpretationType());
 
-  const auto& result = polymorphicDispatcher->fromInterpretation(value, false, e); //useUnqualifiedNames is new to oatpp 1.4.0
+  const auto& result = polymorphicDispatcher->fromInterpretation(value, false, e);
 
   if(e == data::type::EnumInterpreterError::OK) {
     return result;

--- a/src/oatpp-postgresql/mapping/Deserializer.hpp
+++ b/src/oatpp-postgresql/mapping/Deserializer.hpp
@@ -28,9 +28,9 @@
 
 #include "PgArray.hpp"
 
-#include "oatpp/core/data/stream/BufferStream.hpp"
-#include "oatpp/core/data/mapping/TypeResolver.hpp"
-#include "oatpp/core/Types.hpp"
+#include "oatpp/data/stream/BufferStream.hpp"
+#include "oatpp/data/mapping/TypeResolver.hpp"
+#include "oatpp/Types.hpp"
 
 #include <libpq-fe.h>
 
@@ -78,7 +78,7 @@ public:
 
   Deserializer();
 
-  void setDeserializerMethod(const data::mapping::type::ClassId& classId, DeserializerMethod method);
+  void setDeserializerMethod(const data::type::ClassId& classId, DeserializerMethod method);
 
   oatpp::Void deserialize(const InData& data, const Type* type) const;
 

--- a/src/oatpp-postgresql/mapping/PgArray.hpp
+++ b/src/oatpp-postgresql/mapping/PgArray.hpp
@@ -26,8 +26,8 @@
 #ifndef oatpp_postgresql_mapping_PgArray_hpp
 #define oatpp_postgresql_mapping_PgArray_hpp
 
-#include "oatpp/core/data/stream/Stream.hpp"
-#include "oatpp/core/Types.hpp"
+#include "oatpp/data/stream/Stream.hpp"
+#include "oatpp/Types.hpp"
 
 #include <libpq-fe.h>
 

--- a/src/oatpp-postgresql/mapping/ResultMapper.hpp
+++ b/src/oatpp-postgresql/mapping/ResultMapper.hpp
@@ -26,8 +26,8 @@
 #define oatpp_postgresql_mapping_ResultMapper_hpp
 
 #include "Deserializer.hpp"
-#include "oatpp/core/data/mapping/TypeResolver.hpp"
-#include "oatpp/core/Types.hpp"
+#include "oatpp/data/mapping/TypeResolver.hpp"
+#include "oatpp/Types.hpp"
 #include <libpq-fe.h>
 
 namespace oatpp { namespace postgresql { namespace mapping {
@@ -88,7 +88,7 @@ public:
   };
 
 private:
-  typedef oatpp::data::mapping::type::Type Type;
+  typedef oatpp::data::type::Type Type;
   typedef oatpp::Void (*ReadOneRowMethod)(ResultMapper*, ResultData*, const Type*, v_int64);
   typedef oatpp::Void (*ReadRowsMethod)(ResultMapper*, ResultData*, const Type*, v_int64);
 private:
@@ -115,14 +115,14 @@ public:
    * @param classId
    * @param method
    */
-  void setReadOneRowMethod(const data::mapping::type::ClassId& classId, ReadOneRowMethod method);
+  void setReadOneRowMethod(const data::type::ClassId& classId, ReadOneRowMethod method);
 
   /**
    * Set "read rows" method for class id.
    * @param classId
    * @param method
    */
-  void setReadRowsMethod(const data::mapping::type::ClassId& classId, ReadRowsMethod method);
+  void setReadRowsMethod(const data::type::ClassId& classId, ReadRowsMethod method);
 
   /**
    * Read one row to oatpp object or collection. <br>

--- a/src/oatpp-postgresql/mapping/Serializer.cpp
+++ b/src/oatpp-postgresql/mapping/Serializer.cpp
@@ -396,7 +396,7 @@ void Serializer::serializeEnum(const Serializer* _this, OutputData& outData, con
   );
 
   data::type::EnumInterpreterError e = data::type::EnumInterpreterError::OK;
-  const auto& enumInterpretation = polymorphicDispatcher->toInterpretation(polymorph, false, e); //useUnqualifiedNames is new to oatpp 1.4.0
+  const auto& enumInterpretation = polymorphicDispatcher->toInterpretation(polymorph, false, e);
 
   if(e == data::type::EnumInterpreterError::OK) {
     _this->serialize(outData, enumInterpretation);

--- a/src/oatpp-postgresql/mapping/Serializer.cpp
+++ b/src/oatpp-postgresql/mapping/Serializer.cpp
@@ -399,8 +399,23 @@ void Serializer::serializeEnum(const Serializer* _this, OutputData& outData, con
   const auto& enumInterpretation = polymorphicDispatcher->toInterpretation(polymorph, false, e);
 
   if(e == data::type::EnumInterpreterError::OK) {
-    _this->serialize(outData, enumInterpretation);
-    return;
+      if (enumInterpretation &&
+          enumInterpretation.getValueType()->classId == data::type::__class::String::CLASS_ID)
+      {
+          std::string* buff = static_cast<std::string*>(enumInterpretation.get());
+          outData.dataBuffer.reset(new char[buff->size()]);
+          outData.data = outData.dataBuffer.get();
+          outData.dataSize = buff->size();
+          outData.dataFormat = 1;
+          outData.oid = TEXTOID;
+
+          std::memcpy(outData.data, buff->data(), outData.dataSize);
+      }
+      else
+      {
+          _this->serialize(outData, enumInterpretation);
+      }
+      return;
   }
 
   switch(e) {

--- a/src/oatpp-postgresql/mapping/Serializer.cpp
+++ b/src/oatpp-postgresql/mapping/Serializer.cpp
@@ -44,31 +44,31 @@ Serializer::Serializer() {
 
 void Serializer::setSerializerMethods() {
 
-  m_methods.resize(data::mapping::type::ClassId::getClassCount(), nullptr);
+  m_methods.resize(data::type::ClassId::getClassCount(), nullptr);
 
-  setSerializerMethod(data::mapping::type::__class::String::CLASS_ID, &Serializer::serializeString);
+  setSerializerMethod(data::type::__class::String::CLASS_ID, &Serializer::serializeString);
 
-  setSerializerMethod(data::mapping::type::__class::Int8::CLASS_ID, &Serializer::serializeInt8);
-  setSerializerMethod(data::mapping::type::__class::UInt8::CLASS_ID, &Serializer::serializeUInt8);
+  setSerializerMethod(data::type::__class::Int8::CLASS_ID, &Serializer::serializeInt8);
+  setSerializerMethod(data::type::__class::UInt8::CLASS_ID, &Serializer::serializeUInt8);
 
-  setSerializerMethod(data::mapping::type::__class::Int16::CLASS_ID, &Serializer::serializeInt16);
-  setSerializerMethod(data::mapping::type::__class::UInt16::CLASS_ID, &Serializer::serializeUInt16);
+  setSerializerMethod(data::type::__class::Int16::CLASS_ID, &Serializer::serializeInt16);
+  setSerializerMethod(data::type::__class::UInt16::CLASS_ID, &Serializer::serializeUInt16);
 
-  setSerializerMethod(data::mapping::type::__class::Int32::CLASS_ID, &Serializer::serializeInt32);
-  setSerializerMethod(data::mapping::type::__class::UInt32::CLASS_ID, &Serializer::serializeUInt32);
+  setSerializerMethod(data::type::__class::Int32::CLASS_ID, &Serializer::serializeInt32);
+  setSerializerMethod(data::type::__class::UInt32::CLASS_ID, &Serializer::serializeUInt32);
 
-  setSerializerMethod(data::mapping::type::__class::Int64::CLASS_ID, &Serializer::serializeInt64);
-  setSerializerMethod(data::mapping::type::__class::UInt64::CLASS_ID, &Serializer::serializeUInt64);
+  setSerializerMethod(data::type::__class::Int64::CLASS_ID, &Serializer::serializeInt64);
+  setSerializerMethod(data::type::__class::UInt64::CLASS_ID, &Serializer::serializeUInt64);
 
-  setSerializerMethod(data::mapping::type::__class::Float32::CLASS_ID, &Serializer::serializeFloat32);
-  setSerializerMethod(data::mapping::type::__class::Float64::CLASS_ID, &Serializer::serializeFloat64);
-  setSerializerMethod(data::mapping::type::__class::Boolean::CLASS_ID, &Serializer::serializeBoolean);
+  setSerializerMethod(data::type::__class::Float32::CLASS_ID, &Serializer::serializeFloat32);
+  setSerializerMethod(data::type::__class::Float64::CLASS_ID, &Serializer::serializeFloat64);
+  setSerializerMethod(data::type::__class::Boolean::CLASS_ID, &Serializer::serializeBoolean);
 
-  setSerializerMethod(data::mapping::type::__class::AbstractEnum::CLASS_ID, &Serializer::serializeEnum);
+  setSerializerMethod(data::type::__class::AbstractEnum::CLASS_ID, &Serializer::serializeEnum);
 
-  setSerializerMethod(data::mapping::type::__class::AbstractVector::CLASS_ID, &Serializer::serializeArray);
-  setSerializerMethod(data::mapping::type::__class::AbstractList::CLASS_ID, &Serializer::serializeArray);
-  setSerializerMethod(data::mapping::type::__class::AbstractUnorderedSet::CLASS_ID, &Serializer::serializeArray);
+  setSerializerMethod(data::type::__class::AbstractVector::CLASS_ID, &Serializer::serializeArray);
+  setSerializerMethod(data::type::__class::AbstractList::CLASS_ID, &Serializer::serializeArray);
+  setSerializerMethod(data::type::__class::AbstractUnorderedSet::CLASS_ID, &Serializer::serializeArray);
 
   ////
 
@@ -78,48 +78,48 @@ void Serializer::setSerializerMethods() {
 
 void Serializer::setTypeOidMethods() {
 
-  m_typeOidMethods.resize(data::mapping::type::ClassId::getClassCount(), nullptr);
-  m_arrayTypeOidMethods.resize(data::mapping::type::ClassId::getClassCount(), nullptr);
+  m_typeOidMethods.resize(data::type::ClassId::getClassCount(), nullptr);
+  m_arrayTypeOidMethods.resize(data::type::ClassId::getClassCount(), nullptr);
 
-  setTypeOidMethod(data::mapping::type::__class::String::CLASS_ID, &Serializer::getTypeOid<TEXTOID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::String::CLASS_ID, &Serializer::getTypeOid<TEXTARRAYOID>);
+  setTypeOidMethod(data::type::__class::String::CLASS_ID, &Serializer::getTypeOid<TEXTOID>);
+  setArrayTypeOidMethod(data::type::__class::String::CLASS_ID, &Serializer::getTypeOid<TEXTARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Int8::CLASS_ID, &Serializer::getTypeOid<INT2OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Int8::CLASS_ID, &Serializer::getTypeOid<INT2ARRAYOID>);
+  setTypeOidMethod(data::type::__class::Int8::CLASS_ID, &Serializer::getTypeOid<INT2OID>);
+  setArrayTypeOidMethod(data::type::__class::Int8::CLASS_ID, &Serializer::getTypeOid<INT2ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::UInt8::CLASS_ID, &Serializer::getTypeOid<INT2OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::UInt8::CLASS_ID, &Serializer::getTypeOid<INT2ARRAYOID>);
+  setTypeOidMethod(data::type::__class::UInt8::CLASS_ID, &Serializer::getTypeOid<INT2OID>);
+  setArrayTypeOidMethod(data::type::__class::UInt8::CLASS_ID, &Serializer::getTypeOid<INT2ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Int16::CLASS_ID, &Serializer::getTypeOid<INT2OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Int16::CLASS_ID, &Serializer::getTypeOid<INT2ARRAYOID>);
+  setTypeOidMethod(data::type::__class::Int16::CLASS_ID, &Serializer::getTypeOid<INT2OID>);
+  setArrayTypeOidMethod(data::type::__class::Int16::CLASS_ID, &Serializer::getTypeOid<INT2ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::UInt16::CLASS_ID, &Serializer::getTypeOid<INT4OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::UInt16::CLASS_ID, &Serializer::getTypeOid<INT4ARRAYOID>);
+  setTypeOidMethod(data::type::__class::UInt16::CLASS_ID, &Serializer::getTypeOid<INT4OID>);
+  setArrayTypeOidMethod(data::type::__class::UInt16::CLASS_ID, &Serializer::getTypeOid<INT4ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Int32::CLASS_ID, &Serializer::getTypeOid<INT4OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Int32::CLASS_ID, &Serializer::getTypeOid<INT4ARRAYOID>);
+  setTypeOidMethod(data::type::__class::Int32::CLASS_ID, &Serializer::getTypeOid<INT4OID>);
+  setArrayTypeOidMethod(data::type::__class::Int32::CLASS_ID, &Serializer::getTypeOid<INT4ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::UInt32::CLASS_ID, &Serializer::getTypeOid<INT8OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::UInt32::CLASS_ID, &Serializer::getTypeOid<INT8ARRAYOID>);
+  setTypeOidMethod(data::type::__class::UInt32::CLASS_ID, &Serializer::getTypeOid<INT8OID>);
+  setArrayTypeOidMethod(data::type::__class::UInt32::CLASS_ID, &Serializer::getTypeOid<INT8ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Int64::CLASS_ID, &Serializer::getTypeOid<INT8OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Int64::CLASS_ID, &Serializer::getTypeOid<INT8ARRAYOID>);
+  setTypeOidMethod(data::type::__class::Int64::CLASS_ID, &Serializer::getTypeOid<INT8OID>);
+  setArrayTypeOidMethod(data::type::__class::Int64::CLASS_ID, &Serializer::getTypeOid<INT8ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Float32::CLASS_ID, &Serializer::getTypeOid<FLOAT4OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Float32::CLASS_ID, &Serializer::getTypeOid<FLOAT4ARRAYOID>);
+  setTypeOidMethod(data::type::__class::Float32::CLASS_ID, &Serializer::getTypeOid<FLOAT4OID>);
+  setArrayTypeOidMethod(data::type::__class::Float32::CLASS_ID, &Serializer::getTypeOid<FLOAT4ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Float64::CLASS_ID, &Serializer::getTypeOid<FLOAT8OID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Float64::CLASS_ID, &Serializer::getTypeOid<FLOAT8ARRAYOID>);
+  setTypeOidMethod(data::type::__class::Float64::CLASS_ID, &Serializer::getTypeOid<FLOAT8OID>);
+  setArrayTypeOidMethod(data::type::__class::Float64::CLASS_ID, &Serializer::getTypeOid<FLOAT8ARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::Boolean::CLASS_ID, &Serializer::getTypeOid<BOOLOID>);
-  setArrayTypeOidMethod(data::mapping::type::__class::Boolean::CLASS_ID, &Serializer::getTypeOid<BOOLARRAYOID>);
+  setTypeOidMethod(data::type::__class::Boolean::CLASS_ID, &Serializer::getTypeOid<BOOLOID>);
+  setArrayTypeOidMethod(data::type::__class::Boolean::CLASS_ID, &Serializer::getTypeOid<BOOLARRAYOID>);
 
-  setTypeOidMethod(data::mapping::type::__class::AbstractVector::CLASS_ID, &Serializer::get1DCollectionOid);
-  setTypeOidMethod(data::mapping::type::__class::AbstractList::CLASS_ID, &Serializer::get1DCollectionOid);
-  setTypeOidMethod(data::mapping::type::__class::AbstractUnorderedSet::CLASS_ID, &Serializer::get1DCollectionOid);
+  setTypeOidMethod(data::type::__class::AbstractVector::CLASS_ID, &Serializer::get1DCollectionOid);
+  setTypeOidMethod(data::type::__class::AbstractList::CLASS_ID, &Serializer::get1DCollectionOid);
+  setTypeOidMethod(data::type::__class::AbstractUnorderedSet::CLASS_ID, &Serializer::get1DCollectionOid);
 
-  setTypeOidMethod(data::mapping::type::__class::AbstractEnum::CLASS_ID, &Serializer::getEnumTypeOid);
-  setArrayTypeOidMethod(data::mapping::type::__class::AbstractEnum::CLASS_ID, &Serializer::getEnumArrayTypeOid);
+  setTypeOidMethod(data::type::__class::AbstractEnum::CLASS_ID, &Serializer::getEnumTypeOid);
+  setArrayTypeOidMethod(data::type::__class::AbstractEnum::CLASS_ID, &Serializer::getEnumArrayTypeOid);
 
   ////
 
@@ -128,7 +128,7 @@ void Serializer::setTypeOidMethods() {
 
 }
 
-void Serializer::setSerializerMethod(const data::mapping::type::ClassId& classId, SerializerMethod method) {
+void Serializer::setSerializerMethod(const data::type::ClassId& classId, SerializerMethod method) {
   const v_uint32 id = classId.id;
   if(id >= m_methods.size()) {
     m_methods.resize(id + 1, nullptr);
@@ -136,7 +136,7 @@ void Serializer::setSerializerMethod(const data::mapping::type::ClassId& classId
   m_methods[id] = method;
 }
 
-void Serializer::setTypeOidMethod(const data::mapping::type::ClassId& classId, TypeOidMethod method) {
+void Serializer::setTypeOidMethod(const data::type::ClassId& classId, TypeOidMethod method) {
   const v_uint32 id = classId.id;
   if(id >= m_typeOidMethods.size()) {
     m_typeOidMethods.resize(id + 1, nullptr);
@@ -144,7 +144,7 @@ void Serializer::setTypeOidMethod(const data::mapping::type::ClassId& classId, T
   m_typeOidMethods[id] = method;
 }
 
-void Serializer::setArrayTypeOidMethod(const data::mapping::type::ClassId& classId, TypeOidMethod method) {
+void Serializer::setArrayTypeOidMethod(const data::type::ClassId& classId, TypeOidMethod method) {
   const v_uint32 id = classId.id;
   if(id >= m_arrayTypeOidMethods.size()) {
     m_arrayTypeOidMethods.resize(id + 1, nullptr);
@@ -391,20 +391,20 @@ void Serializer::serializeBoolean(const Serializer* _this, OutputData& outData, 
 
 void Serializer::serializeEnum(const Serializer* _this, OutputData& outData, const oatpp::Void& polymorph) {
 
-  auto polymorphicDispatcher = static_cast<const data::mapping::type::__class::AbstractEnum::PolymorphicDispatcher*>(
+  auto polymorphicDispatcher = static_cast<const data::type::__class::AbstractEnum::PolymorphicDispatcher*>(
     polymorph.getValueType()->polymorphicDispatcher
   );
 
-  data::mapping::type::EnumInterpreterError e = data::mapping::type::EnumInterpreterError::OK;
-  const auto& enumInterpretation = polymorphicDispatcher->toInterpretation(polymorph, e);
+  data::type::EnumInterpreterError e = data::type::EnumInterpreterError::OK;
+  const auto& enumInterpretation = polymorphicDispatcher->toInterpretation(polymorph, false, e); //useUnqualifiedNames is new to oatpp 1.4.0
 
-  if(e == data::mapping::type::EnumInterpreterError::OK) {
+  if(e == data::type::EnumInterpreterError::OK) {
     _this->serialize(outData, enumInterpretation);
     return;
   }
 
   switch(e) {
-    case data::mapping::type::EnumInterpreterError::CONSTRAINT_NOT_NULL:
+    case data::type::EnumInterpreterError::CONSTRAINT_NOT_NULL:
       throw std::runtime_error("[oatpp::postgresql::mapping::Serializer::serializeEnum()]: Error. Enum constraint violated - 'NotNull'.");
     default:
       throw std::runtime_error("[oatpp::postgresql::mapping::Serializer::serializeEnum()]: Error. Can't serialize Enum.");
@@ -414,7 +414,7 @@ void Serializer::serializeEnum(const Serializer* _this, OutputData& outData, con
 
 Oid Serializer::getEnumTypeOid(const Serializer* _this, const oatpp::Type* type) {
 
-  auto polymorphicDispatcher = static_cast<const data::mapping::type::__class::AbstractEnum::PolymorphicDispatcher*>(
+  auto polymorphicDispatcher = static_cast<const data::type::__class::AbstractEnum::PolymorphicDispatcher*>(
     type->polymorphicDispatcher
   );
 
@@ -425,7 +425,7 @@ Oid Serializer::getEnumTypeOid(const Serializer* _this, const oatpp::Type* type)
 
 Oid Serializer::getEnumArrayTypeOid(const Serializer* _this, const oatpp::Type* type) {
 
-  auto polymorphicDispatcher = static_cast<const data::mapping::type::__class::AbstractEnum::PolymorphicDispatcher*>(
+  auto polymorphicDispatcher = static_cast<const data::type::__class::AbstractEnum::PolymorphicDispatcher*>(
     type->polymorphicDispatcher
   );
 
@@ -473,7 +473,7 @@ const oatpp::Type* Serializer::getArrayItemTypeAndDimensions(const oatpp::Void& 
                                "The nested container can't be null.");
     }
 
-    auto dispatcher = static_cast<const data::mapping::type::__class::Collection::PolymorphicDispatcher*>(curr.getValueType()->polymorphicDispatcher);
+    auto dispatcher = static_cast<const data::type::__class::Collection::PolymorphicDispatcher*>(curr.getValueType()->polymorphicDispatcher);
     auto size = dispatcher->getCollectionSize(curr);
     dimensions.push_back(size);
 
@@ -501,7 +501,7 @@ void Serializer::serializeSubArray(data::stream::ConsistentOutputStream* stream,
     throw std::runtime_error("[oatpp::postgresql::mapping::Serializer::serializeSubArray()]: Error. Unknown collection type.");
   }
 
-  auto dispatcher = static_cast<const data::mapping::type::__class::Collection::PolymorphicDispatcher*>(type->polymorphicDispatcher);
+  auto dispatcher = static_cast<const data::type::__class::Collection::PolymorphicDispatcher*>(type->polymorphicDispatcher);
   const oatpp::Type* itemType = dispatcher->getItemType();
 
   if(dimension < meta.dimensions.size() - 1) {

--- a/src/oatpp-postgresql/mapping/Serializer.hpp
+++ b/src/oatpp-postgresql/mapping/Serializer.hpp
@@ -27,8 +27,8 @@
 #define oatpp_postgresql_mapping_Serializer_hpp
 
 #include "PgArray.hpp"
-#include "oatpp/core/data/stream/BufferStream.hpp"
-#include "oatpp/core/Types.hpp"
+#include "oatpp/data/stream/BufferStream.hpp"
+#include "oatpp/Types.hpp"
 
 #include <libpq-fe.h>
 
@@ -77,9 +77,9 @@ public:
 
   Serializer();
 
-  void setSerializerMethod(const data::mapping::type::ClassId& classId, SerializerMethod method);
-  void setTypeOidMethod(const data::mapping::type::ClassId& classId, TypeOidMethod method);
-  void setArrayTypeOidMethod(const data::mapping::type::ClassId& classId, TypeOidMethod method);
+  void setSerializerMethod(const data::type::ClassId& classId, SerializerMethod method);
+  void setTypeOidMethod(const data::type::ClassId& classId, TypeOidMethod method);
+  void setArrayTypeOidMethod(const data::type::ClassId& classId, TypeOidMethod method);
 
   void serialize(OutputData& outData, const oatpp::Void& polymorph) const;
 

--- a/src/oatpp-postgresql/mapping/type/Uuid.cpp
+++ b/src/oatpp-postgresql/mapping/type/Uuid.cpp
@@ -24,7 +24,7 @@
 
 #include "Uuid.hpp"
 #include "oatpp/encoding/Hex.hpp"
-#include "oatpp/core/data/stream/BufferStream.hpp"
+#include "oatpp/data/stream/BufferStream.hpp"
 
 namespace oatpp { namespace postgresql { namespace mapping { namespace type {
 

--- a/src/oatpp-postgresql/mapping/type/Uuid.hpp
+++ b/src/oatpp-postgresql/mapping/type/Uuid.hpp
@@ -25,7 +25,7 @@
 #ifndef oatpp_postgresql_mapping_type_Uuid_hpp
 #define oatpp_postgresql_mapping_type_Uuid_hpp
 
-#include "oatpp/core/Types.hpp"
+#include "oatpp/Types.hpp"
 
 namespace oatpp { namespace postgresql { namespace mapping { namespace type {
 
@@ -81,7 +81,7 @@ public:
 /**
  * UUID type to store UUID data.
  */
-typedef oatpp::data::mapping::type::Primitive<UuidObject, __class::Uuid> Uuid;
+typedef oatpp::data::type::Primitive<UuidObject, __class::Uuid> Uuid;
 
 namespace __class {
 

--- a/src/oatpp-postgresql/orm.hpp
+++ b/src/oatpp-postgresql/orm.hpp
@@ -32,7 +32,7 @@
  *
  * #include "oatpp/orm/SchemaMigration.hpp"
  * #include "oatpp/orm/DbClient.hpp"
- * #include "oatpp/core/macro/codegen.hpp"
+ * #include "oatpp/macro/codegen.hpp"
  * ```
  */
 
@@ -44,6 +44,6 @@
 
 #include "oatpp/orm/SchemaMigration.hpp"
 #include "oatpp/orm/DbClient.hpp"
-#include "oatpp/core/macro/codegen.hpp"
+#include "oatpp/macro/codegen.hpp"
 
 #endif // oatpp_postgresql_orm_hpp

--- a/src/oatpp-postgresql/ql_template/Parser.cpp
+++ b/src/oatpp-postgresql/ql_template/Parser.cpp
@@ -24,15 +24,15 @@
 
 #include "Parser.hpp"
 
-#include "oatpp/core/data/stream/BufferStream.hpp"
-#include "oatpp/core/parser/ParsingError.hpp"
+#include "oatpp/data/stream/BufferStream.hpp"
+#include "oatpp/utils/parser/ParsingError.hpp"
 
 namespace oatpp { namespace postgresql { namespace ql_template {
 
 oatpp::String Parser::preprocess(const oatpp::String& text, std::vector<CleanSection>& cleanSections) {
 
   data::stream::BufferOutputStream ss;
-  parser::Caret caret(text);
+  utils::parser::Caret caret(text);
 
   bool writeChar = true;
 
@@ -104,7 +104,7 @@ oatpp::String Parser::preprocess(const oatpp::String& text, std::vector<CleanSec
 
 }
 
-data::share::StringTemplate::Variable Parser::parseIdentifier(parser::Caret& caret) {
+data::share::StringTemplate::Variable Parser::parseIdentifier(utils::parser::Caret& caret) {
   data::share::StringTemplate::Variable result;
   result.posStart = caret.getPosition();
   if(caret.canContinueAtChar(':', 1)) {
@@ -127,7 +127,7 @@ data::share::StringTemplate::Variable Parser::parseIdentifier(parser::Caret& car
   return result;
 }
 
-void Parser::skipStringInQuotes(parser::Caret& caret) {
+void Parser::skipStringInQuotes(utils::parser::Caret& caret) {
 
   bool opened = false;
   while(caret.canContinueAtChar('\'', 1)) {
@@ -144,7 +144,7 @@ void Parser::skipStringInQuotes(parser::Caret& caret) {
 
 }
 
-void Parser::skipStringInDollars(parser::Caret& caret) {
+void Parser::skipStringInDollars(utils::parser::Caret& caret) {
 
   if(caret.canContinueAtChar('$', 1)) {
 
@@ -178,7 +178,7 @@ data::share::StringTemplate Parser::parseTemplate(const oatpp::String& text) {
   std::vector<CleanSection> cleanSections;
   auto processedText = preprocess(text, cleanSections);
 
-  parser::Caret caret(processedText);
+  utils::parser::Caret caret(processedText);
 
   std::vector<data::share::StringTemplate::Variable> variables;
 
@@ -215,7 +215,7 @@ data::share::StringTemplate Parser::parseTemplate(const oatpp::String& text) {
   }
 
   if(caret.hasError()) {
-    throw oatpp::parser::ParsingError(caret.getErrorMessage(), caret.getErrorCode(), caret.getPosition());
+    throw oatpp::utils::parser::ParsingError(caret.getErrorMessage(), caret.getErrorCode(), caret.getPosition());
   }
 
   return data::share::StringTemplate(processedText, std::move(variables));

--- a/src/oatpp-postgresql/ql_template/Parser.hpp
+++ b/src/oatpp-postgresql/ql_template/Parser.hpp
@@ -26,7 +26,7 @@
 #define oatpp_postgresql_ql_template_Parser_hpp
 
 #include "oatpp/orm/Executor.hpp"
-#include "oatpp/core/parser/Caret.hpp"
+#include "oatpp/utils/parser/Caret.hpp"
 
 #include <libpq-fe.h>
 
@@ -77,9 +77,9 @@ public:
   };
 
 private:
-  static data::share::StringTemplate::Variable parseIdentifier(parser::Caret& caret);
-  static void skipStringInQuotes(parser::Caret& caret);
-  static void skipStringInDollars(parser::Caret& caret);
+  static data::share::StringTemplate::Variable parseIdentifier(utils::parser::Caret& caret);
+  static void skipStringInQuotes(utils::parser::Caret& caret);
+  static void skipStringInDollars(utils::parser::Caret& caret);
 public:
 
   /**

--- a/src/oatpp-postgresql/ql_template/TemplateValueProvider.hpp
+++ b/src/oatpp-postgresql/ql_template/TemplateValueProvider.hpp
@@ -26,7 +26,7 @@
 #define oatpp_postgresql_ql_template_TemplateValueProvider_hpp
 
 #include "oatpp/orm/Executor.hpp"
-#include "oatpp/core/data/stream/BufferStream.hpp"
+#include "oatpp/data/stream/BufferStream.hpp"
 
 namespace oatpp { namespace postgresql { namespace ql_template {
 

--- a/test/oatpp-postgresql/migration/EnumAsStringTest.sql
+++ b/test/oatpp-postgresql/migration/EnumAsStringTest.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS test_enumasstring;
+
+CREATE TABLE test_enumasstring (
+  f_enumint      int,
+  f_enumstring   varchar(256)
+);
+
+INSERT INTO test_enumasstring
+(f_enumint, f_enumstring) VALUES (null, null);
+
+INSERT INTO test_enumasstring
+(f_enumint, f_enumstring) VALUES (0, 'dog');
+
+INSERT INTO test_enumasstring
+(f_enumint, f_enumstring) VALUES (1, 'cat');

--- a/test/oatpp-postgresql/ql_template/ParserTest.cpp
+++ b/test/oatpp-postgresql/ql_template/ParserTest.cpp
@@ -41,9 +41,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(result == text);
 
@@ -54,9 +54,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(result == text);
 
@@ -67,9 +67,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT  *  FROM my_table;");
@@ -85,9 +85,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT * FROM my_table;");
@@ -103,9 +103,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT  *  FROM!!> my_table;");
@@ -121,9 +121,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT  <!!*  FROM!!> my_table;");
@@ -139,9 +139,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 0);
     OATPP_ASSERT(result == text);
@@ -152,9 +152,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 2);
     OATPP_ASSERT(result == "SELECT  schedule[1:2][2]  FROM my_table;");
@@ -178,9 +178,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT  * '!!>' FROM my_table;");
@@ -198,9 +198,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT '<!!' *  FROM my_table;");
@@ -218,9 +218,9 @@ void ParserTest::onRun() {
     std::vector<Parser::CleanSection> sections;
     auto result = Parser::preprocess(text, sections);
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(sections.size() == 1);
     OATPP_ASSERT(result == "SELECT *  FROM my_table;");
@@ -239,9 +239,9 @@ void ParserTest::onRun() {
     auto temp = Parser::parseTemplate(text);
     auto result = temp.format("<val>");
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(result == "SELECT  name::text  FROM my_table WHERE id=<val>;");
   }
@@ -252,9 +252,9 @@ void ParserTest::onRun() {
     auto temp = Parser::parseTemplate(text);
     auto result = temp.format("<val>");
 
-    OATPP_LOGD(TAG, "--- case ---");
-    OATPP_LOGD(TAG, "sql='%s'", text->c_str());
-    OATPP_LOGD(TAG, "res='%s'", result->c_str());
+    OATPP_LOGd(TAG, "--- case ---");
+    OATPP_LOGd(TAG, "sql='{}'", text->c_str());
+    OATPP_LOGd(TAG, "res='{}'", result->c_str());
 
     OATPP_ASSERT(result == "SELECT  name::text  FROM my_table WHERE  id=:id ;");
   }

--- a/test/oatpp-postgresql/tests.cpp
+++ b/test/oatpp-postgresql/tests.cpp
@@ -36,14 +36,13 @@ void runTests() {
     std::this_thread::sleep_for(std::chrono::seconds(10));
   }
 
-  //OATPP_RUN_TEST(oatpp::test::postgresql::ql_template::ParserTest);
+  OATPP_RUN_TEST(oatpp::test::postgresql::ql_template::ParserTest);
 
-  //OATPP_RUN_TEST(oatpp::test::postgresql::types::IntTest);
-  //OATPP_RUN_TEST(oatpp::test::postgresql::types::FloatTest);
-  //OATPP_RUN_TEST(oatpp::test::postgresql::types::ArrayTest);
-  //OATPP_RUN_TEST(oatpp::test::postgresql::types::InterpretationTest);
-  //OATPP_RUN_TEST(oatpp::test::postgresql::types::CharacterTest);
-
+  OATPP_RUN_TEST(oatpp::test::postgresql::types::IntTest);
+  OATPP_RUN_TEST(oatpp::test::postgresql::types::FloatTest);
+  OATPP_RUN_TEST(oatpp::test::postgresql::types::ArrayTest);
+  OATPP_RUN_TEST(oatpp::test::postgresql::types::InterpretationTest);
+  OATPP_RUN_TEST(oatpp::test::postgresql::types::CharacterTest);
   OATPP_RUN_TEST(oatpp::test::postgresql::types::EnumAsStringTest);
 }
 

--- a/test/oatpp-postgresql/tests.cpp
+++ b/test/oatpp-postgresql/tests.cpp
@@ -9,7 +9,7 @@
 
 
 #include "oatpp-postgresql/orm.hpp"
-#include "oatpp/core/base/Environment.hpp"
+#include "oatpp/Environment.hpp"
 
 #include <thread>
 #include <chrono>
@@ -18,20 +18,20 @@ namespace {
 
 void runTests() {
 
-  OATPP_LOGI("Tests", "DB-URL='%s'", TEST_DB_URL);
+  OATPP_LOGi("Tests", "DB-URL='{}'", TEST_DB_URL);
   auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
   for(v_int32 i = 0; i < 6; i ++) {
     try {
       auto connection = connectionProvider->get();
       if(connection) {
-        OATPP_LOGD("Tests", "Database is up! We've got a connection!");
+        OATPP_LOGd("Tests", "Database is up! We've got a connection!");
         break;
       }
     } catch (...) {
       // DO NOTHING
     }
 
-    OATPP_LOGD("Tests", "Database is not ready. Sleep 10s...");
+    OATPP_LOGd("Tests", "Database is not ready. Sleep 10s...");
     std::this_thread::sleep_for(std::chrono::seconds(10));
   }
 
@@ -48,9 +48,9 @@ void runTests() {
 }
 
 int main() {
-  oatpp::base::Environment::init();
+  oatpp::Environment::init();
   runTests();
-  OATPP_ASSERT(oatpp::base::Environment::getObjectsCount() == 0);
-  oatpp::base::Environment::destroy();
+  OATPP_ASSERT(oatpp::Environment::getObjectsCount() == 0);
+  oatpp::Environment::destroy();
   return 0;
 }

--- a/test/oatpp-postgresql/tests.cpp
+++ b/test/oatpp-postgresql/tests.cpp
@@ -6,6 +6,7 @@
 #include "types/FloatTest.hpp"
 #include "types/InterpretationTest.hpp"
 #include "types/CharacterTest.hpp"
+#include "types/EnumAsStringTest.hpp"
 
 
 #include "oatpp-postgresql/orm.hpp"
@@ -35,14 +36,15 @@ void runTests() {
     std::this_thread::sleep_for(std::chrono::seconds(10));
   }
 
-  OATPP_RUN_TEST(oatpp::test::postgresql::ql_template::ParserTest);
+  //OATPP_RUN_TEST(oatpp::test::postgresql::ql_template::ParserTest);
 
-  OATPP_RUN_TEST(oatpp::test::postgresql::types::IntTest);
-  OATPP_RUN_TEST(oatpp::test::postgresql::types::FloatTest);
-  OATPP_RUN_TEST(oatpp::test::postgresql::types::ArrayTest);
-  OATPP_RUN_TEST(oatpp::test::postgresql::types::InterpretationTest);
-  OATPP_RUN_TEST(oatpp::test::postgresql::types::CharacterTest);
+  //OATPP_RUN_TEST(oatpp::test::postgresql::types::IntTest);
+  //OATPP_RUN_TEST(oatpp::test::postgresql::types::FloatTest);
+  //OATPP_RUN_TEST(oatpp::test::postgresql::types::ArrayTest);
+  //OATPP_RUN_TEST(oatpp::test::postgresql::types::InterpretationTest);
+  //OATPP_RUN_TEST(oatpp::test::postgresql::types::CharacterTest);
 
+  OATPP_RUN_TEST(oatpp::test::postgresql::types::EnumAsStringTest);
 }
 
 }

--- a/test/oatpp-postgresql/types/ArrayTest.cpp
+++ b/test/oatpp-postgresql/types/ArrayTest.cpp
@@ -25,7 +25,7 @@
 #include "ArrayTest.hpp"
 
 #include "oatpp-postgresql/orm.hpp"
-#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+#include "oatpp/json/ObjectMapper.hpp"
 
 namespace oatpp { namespace test { namespace postgresql { namespace types {
 
@@ -79,7 +79,7 @@ public:
     migration.migrate();
 
     auto version = executor->getSchemaVersion("ArrayTest");
-    OATPP_LOGD("DbClient", "Migration - OK. Version=%d.", version);
+    OATPP_LOGd("DbClient", "Migration - OK. Version={}.", version);
 
   }
 
@@ -109,7 +109,7 @@ public:
 
 void ArrayTest::onRun() {
 
-  OATPP_LOGI(TAG, "DB-URL='%s'", TEST_DB_URL);
+  OATPP_LOGi(TAG, "DB-URL='{}'", TEST_DB_URL);
 
   auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
   auto connectionPool = oatpp::postgresql::ConnectionPool::createShared(connectionProvider,
@@ -131,10 +131,10 @@ void ArrayTest::onRun() {
 
     auto res = client.insertValues1(row);
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
   }
@@ -142,10 +142,10 @@ void ArrayTest::onRun() {
   {
     auto res = client.selectValues1();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row1>>>();
@@ -320,10 +320,10 @@ void ArrayTest::onRun() {
 
     auto res = client.insertValues2(row);
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
   }
@@ -331,10 +331,10 @@ void ArrayTest::onRun() {
   {
     auto res = client.selectValues2();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row2>>>();

--- a/test/oatpp-postgresql/types/CharacterTest.cpp
+++ b/test/oatpp-postgresql/types/CharacterTest.cpp
@@ -25,7 +25,7 @@
 #include "CharacterTest.hpp"
 
 #include "oatpp-postgresql/orm.hpp"
-#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+#include "oatpp/json/ObjectMapper.hpp"
 
 #include <limits>
 #include <cstdio>
@@ -64,7 +64,7 @@ public:
     migration.migrate();
 
     auto version = executor->getSchemaVersion("CharacterTest");
-    OATPP_LOGD("DbClient", "Migration - OK. Version=%d.", version);
+    OATPP_LOGd("DbClient", "Migration - OK. Version={}.", version);
 
   }
 
@@ -88,7 +88,7 @@ public:
 
 void CharacterTest::onRun() {
 
-  OATPP_LOGI(TAG, "DB-URL='%s'", TEST_DB_URL);
+  OATPP_LOGi(TAG, "DB-URL='{}'", TEST_DB_URL);
 
   auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
   auto executor = std::make_shared<oatpp::postgresql::Executor>(connectionProvider);
@@ -98,21 +98,21 @@ void CharacterTest::onRun() {
   {
     auto res = client.selectValues();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row>>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql" };
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 3);
 
@@ -149,10 +149,10 @@ void CharacterTest::onRun() {
   {
     auto res = client.deleteValues();
     if (res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     OATPP_ASSERT(res->isSuccess());
@@ -184,21 +184,21 @@ void CharacterTest::onRun() {
   {
     auto res = client.selectValues();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row>>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql" };
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 2);
 

--- a/test/oatpp-postgresql/types/EnumAsStringTest.cpp
+++ b/test/oatpp-postgresql/types/EnumAsStringTest.cpp
@@ -1,0 +1,227 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "EnumAsStringTest.hpp"
+
+#include "oatpp-postgresql/orm.hpp"
+#include "oatpp/json/ObjectMapper.hpp"
+
+#include <limits>
+#include <cstdio>
+
+namespace oatpp { namespace test { namespace postgresql { namespace types {
+
+namespace {
+
+#include OATPP_CODEGEN_BEGIN(DTO)
+
+ENUM(Animal, v_int32,
+    VALUE(DOG, 0, "dog"),
+    VALUE(CAT, 1, "cat"),
+    VALUE(BIRD, 2, "bird"),
+    VALUE(HORSE, 3, "horse")
+)
+
+class Row : public oatpp::DTO {
+
+  DTO_INIT(Row, DTO);
+
+  DTO_FIELD(Enum<Animal>::AsNumber, f_enumint);
+  DTO_FIELD(Enum<Animal>::AsString, f_enumstring);
+
+};
+
+#include OATPP_CODEGEN_END(DTO)
+
+#include OATPP_CODEGEN_BEGIN(DbClient)
+
+class MyClient : public oatpp::orm::DbClient {
+public:
+
+  MyClient(const std::shared_ptr<oatpp::orm::Executor>& executor)
+    : oatpp::orm::DbClient(executor)
+  {
+    executeQuery("DROP TABLE IF EXISTS oatpp_schema_version_EnumAsStringTest;", {});
+    oatpp::orm::SchemaMigration migration(executor, "EnumAsStringTest");
+    migration.addFile(1, TEST_DB_MIGRATION "EnumAsStringTest.sql");
+    migration.migrate();
+
+    auto version = executor->getSchemaVersion("EnumAsStringTest");
+    OATPP_LOGd("DbClient", "Migration - OK. Version={}.", version);
+
+  }
+
+  QUERY(insertValues,
+        "INSERT INTO test_EnumAsString "
+        "(f_enumint, f_enumstring) "
+        "VALUES "
+        "(:row.f_enumint, :row.f_enumstring);",
+        PARAM(oatpp::Object<Row>, row), PREPARE(true))
+
+  QUERY(deleteValues,
+        "DELETE FROM test_EnumAsString;")
+
+  QUERY(selectValues, "SELECT * FROM test_EnumAsString;")
+
+};
+
+#include OATPP_CODEGEN_END(DbClient)
+
+}
+
+void EnumAsStringTest::onRun() {
+
+  OATPP_LOGi(TAG, "DB-URL='{}'", TEST_DB_URL);
+
+  auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
+  auto executor = std::make_shared<oatpp::postgresql::Executor>(connectionProvider);
+
+  auto client = MyClient(executor);
+
+  {
+    auto res = client.selectValues();
+    if(res->isSuccess()) {
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
+    } else {
+      auto message = res->getErrorMessage();
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
+    }
+
+    auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row>>>();
+
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql" };
+
+    auto str = om.writeToString(dataset);
+
+    OATPP_LOGd(TAG, "res={}", str->c_str());
+
+    OATPP_ASSERT(dataset->size() == 3);
+
+    {
+      auto row = dataset[0];
+      OATPP_ASSERT(row->f_enumint == nullptr);
+      OATPP_ASSERT(row->f_enumstring == nullptr);
+    }
+
+    {
+      auto row = dataset[1];
+      OATPP_ASSERT(row->f_enumint == Animal::DOG);
+      OATPP_ASSERT(row->f_enumstring == Animal::DOG);
+    }
+
+    {
+      auto row = dataset[2];
+      OATPP_ASSERT(row->f_enumint == Animal::CAT);
+      OATPP_ASSERT(row->f_enumstring == Animal::CAT);
+    }
+
+  }
+
+  {
+    auto res = client.deleteValues();
+    if (res->isSuccess()) {
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
+    } else {
+      auto message = res->getErrorMessage();
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
+    }
+
+    OATPP_ASSERT(res->isSuccess());
+  }
+
+  {
+    auto connection = client.getConnection();
+    {
+      auto row = Row::createShared();
+      row->f_enumint = nullptr;
+      row->f_enumstring = nullptr;
+      auto res = client.insertValues(row, connection);
+      if (res->isSuccess()) {
+          OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
+      }
+      else {
+          auto message = res->getErrorMessage();
+          OATPP_LOGd(TAG, "Error, message={}", message->c_str());
+      }
+
+      OATPP_ASSERT(res->isSuccess());
+    }
+
+    {
+      auto row = Row::createShared();
+      row->f_enumint = Animal::HORSE;
+      row->f_enumstring = Animal::HORSE;
+      auto res = client.insertValues(row, connection);
+      if (res->isSuccess()) {
+          OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
+      }
+      else {
+          auto message = res->getErrorMessage();
+          OATPP_LOGd(TAG, "Error, message={}", message->c_str());
+      }
+
+      OATPP_ASSERT(res->isSuccess());
+    }
+  }
+
+  {
+    auto res = client.selectValues();
+    if(res->isSuccess()) {
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
+    } else {
+      auto message = res->getErrorMessage();
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
+    }
+
+    auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row>>>();
+
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql" };
+
+    auto str = om.writeToString(dataset);
+
+    OATPP_LOGd(TAG, "res={}", str->c_str());
+
+    OATPP_ASSERT(dataset->size() == 2);
+
+    {
+      auto row = dataset[0];
+      OATPP_ASSERT(row->f_enumint == nullptr);
+      OATPP_ASSERT(row->f_enumstring == nullptr);
+    }
+
+    {
+      auto row = dataset[1];
+      OATPP_ASSERT(row->f_enumint == Animal::HORSE);
+      OATPP_ASSERT(row->f_enumstring == Animal::HORSE);
+    }
+
+  }
+
+}
+
+}}}}

--- a/test/oatpp-postgresql/types/EnumAsStringTest.hpp
+++ b/test/oatpp-postgresql/types/EnumAsStringTest.hpp
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_postgresql_types_EnumAsStringTest_hpp
+#define oatpp_test_postgresql_types_EnumAsStringTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace postgresql { namespace types {
+
+class EnumAsStringTest : public UnitTest {
+public:
+  EnumAsStringTest() : UnitTest("TEST[postgresql::types::EnumAsStringTest]") {}
+  void onRun() override;
+};
+
+}}}}
+
+#endif // oatpp_test_postgresql_types_EnumAsStringTest_hpp

--- a/test/oatpp-postgresql/types/FloatTest.cpp
+++ b/test/oatpp-postgresql/types/FloatTest.cpp
@@ -25,7 +25,7 @@
 #include "FloatTest.hpp"
 
 #include "oatpp-postgresql/orm.hpp"
-#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+#include "oatpp/json/ObjectMapper.hpp"
 
 #include <limits>
 #include <cstdio>
@@ -63,7 +63,7 @@ public:
     migration.migrate();
 
     auto version = executor->getSchemaVersion("FloatTest");
-    OATPP_LOGD("DbClient", "Migration - OK. Version=%d.", version);
+    OATPP_LOGd("DbClient", "Migration - OK. Version={}.", version);
 
   }
 
@@ -87,7 +87,7 @@ public:
 
 void FloatTest::onRun() {
 
-  OATPP_LOGI(TAG, "DB-URL='%s'", TEST_DB_URL);
+  OATPP_LOGi(TAG, "DB-URL='{}'", TEST_DB_URL);
 
   auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
   auto executor = std::make_shared<oatpp::postgresql::Executor>(connectionProvider);
@@ -97,21 +97,21 @@ void FloatTest::onRun() {
   {
     auto res = client.selectValues();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row>>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = {"postgresql"};
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 4);
 
@@ -144,10 +144,10 @@ void FloatTest::onRun() {
   {
     auto res = client.deleteValues();
     if (res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     OATPP_ASSERT(res->isSuccess());
@@ -173,21 +173,21 @@ void FloatTest::onRun() {
   {
     auto res = client.selectValues();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<Row>>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql" };
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 2);
 

--- a/test/oatpp-postgresql/types/IntTest.cpp
+++ b/test/oatpp-postgresql/types/IntTest.cpp
@@ -25,7 +25,7 @@
 #include "IntTest.hpp"
 
 #include "oatpp-postgresql/orm.hpp"
-#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+#include "oatpp/json/ObjectMapper.hpp"
 
 #include <limits>
 #include <cstdio>
@@ -72,7 +72,7 @@ public:
     migration.migrate();
 
     auto version = executor->getSchemaVersion("IntTest");
-    OATPP_LOGD("DbClient", "Migration - OK. Version=%d.", version);
+    OATPP_LOGd("DbClient", "Migration - OK. Version={}.", version);
 
   }
 
@@ -98,7 +98,7 @@ public:
 
 void IntTest::onRun() {
 
-  OATPP_LOGI(TAG, "DB-URL='%s'", TEST_DB_URL);
+  OATPP_LOGi(TAG, "DB-URL='{}'", TEST_DB_URL);
 
   auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
   auto executor = std::make_shared<oatpp::postgresql::Executor>(connectionProvider);
@@ -137,21 +137,21 @@ void IntTest::onRun() {
   {
     auto res = client.selectAllInts();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<IntsRow>>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql" };
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 4);
 

--- a/test/oatpp-postgresql/types/InterpretationTest.cpp
+++ b/test/oatpp-postgresql/types/InterpretationTest.cpp
@@ -25,8 +25,8 @@
 #include "InterpretationTest.hpp"
 
 #include "oatpp-postgresql/orm.hpp"
-#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
-#include "oatpp/core/utils/ConversionUtils.hpp"
+#include "oatpp/json/ObjectMapper.hpp"
+#include "oatpp/utils/Conversion.hpp"
 
 #include <limits>
 #include <cstdio>
@@ -54,9 +54,9 @@ namespace __class {
  class StringNumberClass;
 }
 
-typedef oatpp::data::mapping::type::Primitive<VPoint, __class::PointClass> Point;
-typedef oatpp::data::mapping::type::Primitive<VLine, __class::LineClass> Line;
-typedef oatpp::data::mapping::type::ObjectWrapper<std::string, __class::StringNumberClass> StringNumber;
+typedef oatpp::data::type::Primitive<VPoint, __class::PointClass> Point;
+typedef oatpp::data::type::Primitive<VLine, __class::LineClass> Line;
+typedef oatpp::data::type::ObjectWrapper<std::string, __class::StringNumberClass> StringNumber;
 
 namespace __class {
 
@@ -77,7 +77,7 @@ namespace __class {
     public:
 
       oatpp::Object<PointDto> interpret(const Point &value) const override {
-        OATPP_LOGD("Point::Interpretation", "interpret");
+        OATPP_LOGd("Point::Interpretation", "interpret");
         auto dto = PointDto::createShared();
         dto->x = value->x;
         dto->y = value->y;
@@ -86,7 +86,7 @@ namespace __class {
       }
 
       Point reproduce(const oatpp::Object<PointDto> &value) const override {
-        OATPP_LOGD("Point::Interpretation", "reproduce");
+        OATPP_LOGd("Point::Interpretation", "reproduce");
         return Point({value->x, value->y, value->z});
       }
 
@@ -129,7 +129,7 @@ namespace __class {
     public:
 
       oatpp::Object<LineDto> interpret(const Line &value) const override {
-        OATPP_LOGD("Line::Interpretation", "interpret");
+        OATPP_LOGd("Line::Interpretation", "interpret");
         auto dto = LineDto::createShared();
         dto->p1 = {value->p1.x, value->p1.y, value->p1.z};
         dto->p2 = {value->p2.x, value->p2.y, value->p2.z};
@@ -137,7 +137,7 @@ namespace __class {
       }
 
       Line reproduce(const oatpp::Object<LineDto> &value) const override {
-        OATPP_LOGD("Line::Interpretation", "reproduce");
+        OATPP_LOGd("Line::Interpretation", "reproduce");
         return Line({{value->p1->x, value->p1->y, value->p1->z},
                      {value->p2->x, value->p2->y, value->p2->z}});
       }
@@ -172,13 +172,13 @@ namespace __class {
     public:
 
       oatpp::Int64 interpret(const StringNumber& value) const override {
-        OATPP_LOGD("StringNumber::Interpretation", "interpret");
-        return oatpp::utils::conversion::strToInt64(value->c_str());
+        OATPP_LOGd("StringNumber::Interpretation", "interpret");
+        return oatpp::utils::Conversion::strToInt64(value->c_str());
       }
 
       StringNumber reproduce(const oatpp::Int64& value) const override {
-        OATPP_LOGD("StringNumber::Interpretation", "reproduce");
-        return oatpp::utils::conversion::int64ToStr(value).getPtr();
+        OATPP_LOGd("StringNumber::Interpretation", "reproduce");
+        return oatpp::utils::Conversion::int64ToStr(value).getPtr();
       }
 
     };
@@ -239,7 +239,7 @@ public:
     migration.migrate();
 
     auto version = executor->getSchemaVersion("InterpretationTest");
-    OATPP_LOGD("DbClient", "Migration - OK. Version=%d.", version);
+    OATPP_LOGd("DbClient", "Migration - OK. Version={}.", version);
 
     setEnabledInterpretations({"test"});
 
@@ -271,7 +271,7 @@ public:
 
 void InterpretationTest::onRun() {
 
-  OATPP_LOGI(TAG, "DB-URL='%s'", TEST_DB_URL);
+  OATPP_LOGi(TAG, "DB-URL='{}'", TEST_DB_URL);
 
   auto connectionProvider = std::make_shared<oatpp::postgresql::ConnectionProvider>(TEST_DB_URL);
   auto executor = std::make_shared<oatpp::postgresql::Executor>(connectionProvider);
@@ -311,21 +311,21 @@ void InterpretationTest::onRun() {
   {
     auto res = client.selectPoints();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<Point>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql", "test"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql", "test" };
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 3);
 
@@ -395,21 +395,21 @@ void InterpretationTest::onRun() {
   {
     auto res = client.selectLines();
     if(res->isSuccess()) {
-      OATPP_LOGD(TAG, "OK, knownCount=%d, hasMore=%d", res->getKnownCount(), res->hasMoreToFetch());
+      OATPP_LOGd(TAG, "OK, knownCount={}, hasMore={}", res->getKnownCount(), res->hasMoreToFetch());
     } else {
       auto message = res->getErrorMessage();
-      OATPP_LOGD(TAG, "Error, message=%s", message->c_str());
+      OATPP_LOGd(TAG, "Error, message={}", message->c_str());
     }
 
     auto dataset = res->fetch<oatpp::Vector<oatpp::Object<LineInterRow>>>();
 
-    oatpp::parser::json::mapping::ObjectMapper om;
-    om.getSerializer()->getConfig()->useBeautifier = true;
-    om.getSerializer()->getConfig()->enabledInterpretations = {"postgresql", "test"};
+    oatpp::json::ObjectMapper om;
+    om.serializerConfig().json.useBeautifier = true;
+    om.serializerConfig().mapper.enabledInterpretations = { "postgresql", "test" };
 
     auto str = om.writeToString(dataset);
 
-    OATPP_LOGD(TAG, "res=%s", str->c_str());
+    OATPP_LOGd(TAG, "res={}", str->c_str());
 
     OATPP_ASSERT(dataset->size() == 3);
 


### PR DESCRIPTION
Issue #24 
When serializing a DTO that contains a DTO_FIELD whose type is `Enum<xxx>AsString`, the resulting string ultimately goes out of scope. This will result in a failure when trying to insert this type of value into a database.

The solution is to utilize Serializer::OutputData::databuffer. Before the enum string goes out of scope, allocate a dataBuffer and copy the value to it.

EnumAsStringTest is included as a unit test. 

If you run the unit test before applying the Serializer change you can see the failure take place.

Regarding Oatpp 1.4.0
My environment is set up using Oatpp 1.4.0.  
I updated oatpp-postresql to 1.4.0 to explore.
I then discovered issue #24 and created the solution in the 1.4.0 environment.